### PR TITLE
Add argument to ordinal to support <sup> tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Converts an integer to its ordinal as a string. 1 is '1st', 2 is '2nd', 3 is '3r
 ```
 {{ somenum }} >>> 3
 {{ somenum | ordinal }} >>> '3rd'
+{{ somenum | ordinal:'sup' }} >>> '3<sup>rd</sup>'
 ```
 
 ### intcomma(_value_, _delimiter=","_)

--- a/humanize.rb
+++ b/humanize.rb
@@ -16,7 +16,7 @@ module Jekyll
     #  PUBLIC METHODS  #
     ####################
 
-    def ordinal(value)
+    def ordinal(value, tag=nil)
       ##
       # Converts an integer to its ordinal as a string. 1 is '1st', 2 is '2nd',
       # 3 is '3rd', etc. Works for any integer.
@@ -24,6 +24,7 @@ module Jekyll
       # Usage:
       # {{ somenum }} >>> 3
       # {{ somenum | ordinal }} >>> '3rd'
+      # {{ somenum | ordinal:'sup' }} >>> '3<sup>rd</sup>'
 
       begin
         value = value.to_i
@@ -34,11 +35,16 @@ module Jekyll
 
       suffixes = ["th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"]
       unless [11, 12, 13].include? value % 100 then
-        return "#{value}%s" % suffixes[value % 10]
+        suffix = suffixes[value % 10]
       else
-        return "#{value}%s" % suffixes[0]
+        suffix = suffixes[0]
       end
 
+      if tag then
+        return "#{value}<#{tag}>#{suffix}</#{tag}>"
+      else
+        return "#{value}#{suffix}"
+      end
     end
 
     def intcomma(value, delimiter=",")


### PR DESCRIPTION
I got really sad that I couldn't display values in traditional formats on my blog, so I went searching for an answer and I found your lovely extension! But I noticed your ordinal filter doesn't add `<sup>` tags. So I thought I'd fix that for you :sparkling_heart: 

Here's an example use case:

```
{% assign date_month = page.date | date:"%B " %}
{% assign date_day = page.date | date:"%d" | ordinal:'sup' %}
{% assign date_year = page.date | date:", %Y" %}
{% assign date_abbr = date_month | append:date_day | append:date_year %}
```

This is what I use to render the dates on https://justinetunney.com/steve-jobs.html

Thanks in advance for merging. Also sorry about the newlines at the end of the file.
